### PR TITLE
Prevent Travis from Updating Composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,12 @@ matrix:
   allow_failures:
     - php: nightly
 
+# Control installation settings
+before_install:
+  # prevent composer from automatically updating to latest
+  # (until we are ready for Composer 2.0)
+  - composer self-update --1
+
 # Use this to prepare the build for testing.
 before_script:
     # Speed up build time by disabling Xdebug.


### PR DESCRIPTION
Builds are failing on certain (older) versions of PHP during our Travis CI testing. This addition to the `travis.yml` file will prevent Travis from automatically updating to Composer 2.0 when it creates our test environments.

This fixes #32 