### PR TITLE
Initial Readme Structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ matrix:
   allow_failures:
     - php: nightly
 
+# Control installation settings
+before_install:
+  - composer self-update --1
+
 # Use this to prepare the build for testing.
 before_script:
     # Speed up build time by disabling Xdebug.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
   - [Setting Up Local or Lando](#setting-up-local-or-lando)
     - [Local By Flywheel](#local-by-flywheel)
     - [Lando](#lando)
+  - [Cloning the Theme](#cloning-the-theme)
   - [Installing Dependencies](#installing-dependencies)
   - [Installing Dependencies from the ASU Unity Design System](#installing-dependencies-from-the-asu-unity-design-system)
   - [Contributing to the Theme](#contributing-to-the-theme)
@@ -105,7 +106,8 @@ There are several solutions available for hosting local WordPress development si
 #### Local By Flywheel
 #### Lando
 
-Once you have been able to install and run a local version of WordPress, clone this repository into the `wp-content/themes` folder and continue with the installation process below.
+### Cloning the Theme
+Once you have been able to install and run a local version of WordPress, clone [theme repository](https://github.com/asu-ke-web-services/UDS-WordPress-Theme.git) into the `wp-content/themes` folder and continue with the installation process below.
 
 ### Installing Dependencies
 - Make sure you have installed Node.js and Browser-Sync (optional) on your computer globally

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@
 - [❯ Getting Started](#-getting-started)
   - [Installing the Theme](#installing-the-theme)
   - [Updating the Theme](#updating-the-theme)
-    - [Using Github Updater](#using-github-updater)
   - [Using the Theme](#using-the-theme)
 - [❯ For Developers](#-for-developers)
+  - [Contributing](#contributing)
   - [Requirements](#requirements)
   - [Local WordPress Environment](#local-wordpress-environment)
     - [Local By Flywheel](#local-by-flywheel)
@@ -41,7 +41,7 @@
   - [Installing Dependencies](#installing-dependencies)
   - [Installing Dependencies from the ASU Unity Design System](#installing-dependencies-from-the-asu-unity-design-system)
     - [Creating a User Account and Saving your NPM Access Token](#creating-a-user-account-and-saving-your-npm-access-token)
-  - [Running](#running)
+  - [Developer Workflow](#developer-workflow)
   - [Project Structure](#project-structure)
 
 
@@ -52,17 +52,27 @@
 
 ### Installing the Theme
 [to-do]
+- instructions here for end-user installing the theme
+- methods? GitHub Updater? Downloaded ZIP file?
 
 ### Updating the Theme
 [to-do]
-
-#### Using Github Updater
-[to-do]
+- instructions here for end-user updating the theme
+- methods? GitHub Updater? Downloaded ZIP file?
 
 ### Using the Theme
 [to-do]
+- customizer options
+- setting a hero image
+- social media icons
+- menus
+- shortcodes(?)
+- ???
 
 ## ❯ For Developers
+
+### Contributing
+[to-do: overall description of contributing??]
 
 ### Requirements
 You need to set up your development environment before you can do anything.
@@ -82,13 +92,14 @@ There are several solutions available for hosting local WordPress development si
 * [wp-local-docker](https://github.com/10up/wp-local-docker) by 10up
 * [VVV](https://varyingvagrantvagrants.org/)
 
-Once you have been able to install and run a local version of WordPress, clone this repository into the `wp-content/themes` folder and continue with the installation process below.
 
 #### Local By Flywheel
-[to-do-local-setup]
+[to-do: local-setup]
 
 #### Lando
-[to-do-lando-setup]
+[to-do: lando-setup]
+
+Once you have been able to install and run a local version of WordPress, clone this repository into the `wp-content/themes` folder and continue with the installation process below.
 
 ### Installing Dependencies
 - Make sure you have installed Node.js and Browser-Sync (optional) on your computer globally
@@ -115,7 +126,13 @@ npm login --registry http://ec2-54-201-88-203.us-west-2.compute.amazonaws.com
 
 Once you have successfully signed-in, npm will automatically save new line to your .npmrc, saving your login token for the future.
 
-### Running
+### Developer Workflow
+[to-do]
+- Travis CI
+- Linting/testing
+- Developer workflow
+- ?? (see current theme README for ideas)
+
 To work with and compile your Sass files on the fly start:
 
 - `$ gulp watch`

--- a/README.md
+++ b/README.md
@@ -25,55 +25,64 @@
 
 ![divider](https://cdn.infonet.research.asu.edu/assets/divider.png)
 
-## ❯ Table of Contents
+## Table of Contents
 
-- [❯ Table of Contents](#-table-of-contents)
+- [Table of Contents](#table-of-contents)
 - [❯ Getting Started](#-getting-started)
-  - [Installing the Theme](#installing-the-theme)
-  - [Updating the Theme](#updating-the-theme)
+  - [Installation](#installation)
+    - [GitHub Updater](#github-updater)
+    - [Installing Required Plugins](#installing-required-plugins)
+    - [Updating the Theme](#updating-the-theme)
   - [Using the Theme](#using-the-theme)
+    - [Customizer Options](#customizer-options)
+    - [Page Heroes](#page-heroes)
+    - [Social Media Icons](#social-media-icons)
+    - [Menus](#menus)
+    - [Shortcodes](#shortcodes)
+    - [Adding Sidebars](#adding-sidebars)
+  - [Reporting Issues](#reporting-issues)
 - [❯ For Developers](#-for-developers)
-  - [Contributing](#contributing)
+  - [Introduction](#introduction)
   - [Requirements](#requirements)
   - [Local WordPress Environment](#local-wordpress-environment)
+  - [Setting Up Local or Lando](#setting-up-local-or-lando)
     - [Local By Flywheel](#local-by-flywheel)
     - [Lando](#lando)
   - [Installing Dependencies](#installing-dependencies)
   - [Installing Dependencies from the ASU Unity Design System](#installing-dependencies-from-the-asu-unity-design-system)
-    - [Creating a User Account and Saving your NPM Access Token](#creating-a-user-account-and-saving-your-npm-access-token)
-  - [Developer Workflow](#developer-workflow)
-  - [Project Structure](#project-structure)
-
+  - [Contributing to the Theme](#contributing-to-the-theme)
+    - [Coding Standards](#coding-standards)
+    - [Code Linting](#code-linting)
+      - [Composer Scripts](#composer-scripts)
+      - [PHPCS](#phpcs)
+    - [Working with Styles](#working-with-styles)
+    - [BroswerSync](#broswersync)
+    - [Travis CI](#travis-ci)
+- [Project Structure](#project-structure)
 
 ![divider](https://cdn.infonet.research.asu.edu/assets/divider.png)
 
-
 ## ❯ Getting Started
 
-### Installing the Theme
-[to-do]
-- instructions here for end-user installing the theme
-- methods? GitHub Updater? Downloaded ZIP file?
-
-### Updating the Theme
-[to-do]
-- instructions here for end-user updating the theme
-- methods? GitHub Updater? Downloaded ZIP file?
+### Installation
+#### GitHub Updater
+#### Installing Required Plugins
+#### Updating the Theme
 
 ### Using the Theme
-[to-do]
-- customizer options
-- setting a hero image
-- social media icons
-- menus
-- shortcodes(?)
-- ???
+#### Customizer Options
+#### Page Heroes
+#### Social Media Icons
+#### Menus
+#### Shortcodes
+#### Adding Sidebars
+
+### Reporting Issues
+
+![divider](https://cdn.infonet.research.asu.edu/assets/divider.png)
 
 ## ❯ For Developers
-
-### Contributing
-[to-do: overall description of contributing??]
-
+### Introduction
 ### Requirements
 You need to set up your development environment before you can do anything.
 
@@ -92,12 +101,9 @@ There are several solutions available for hosting local WordPress development si
 * [wp-local-docker](https://github.com/10up/wp-local-docker) by 10up
 * [VVV](https://varyingvagrantvagrants.org/)
 
-
+### Setting Up Local or Lando
 #### Local By Flywheel
-[to-do: local-setup]
-
 #### Lando
-[to-do: lando-setup]
 
 Once you have been able to install and run a local version of WordPress, clone this repository into the `wp-content/themes` folder and continue with the installation process below.
 
@@ -108,35 +114,17 @@ Once you have been able to install and run a local version of WordPress, clone t
 - Run: `$ npm install`
 
 ### Installing Dependencies from the ASU Unity Design System
-The ASU-produced packages in this theme are loaded from the ASU Unity Private NPM (Verdaccio) package repository. This requires you to sign-in and create a user account on the NPM server. Doing so, npm will automatically save your authentication token into a local .npmrc file located in your home directory.
+- Does this need its own section?
 
-#### Creating a User Account and Saving your NPM Access Token
-1. Visit the ASU Unity NPM Package server and follow directions to add yourself as a user: http://ec2-54-201-88-203.us-west-2.compute.amazonaws.com/
-2. Configure npm to use this private registry. Add the following line to the .npmrc file in your home directory (existing lines can be left in-place):
-
-```
-@asu-design-system:registry=http://ec2-54-201-88-203.us-west-2.compute.amazonaws.com
-```
-
-This config tells npm that all packages from ‘@asu-design-system’ should be grabbed from the ASU private registry. If it says you are not authorized, try to login using:
-
-```
-npm login --registry http://ec2-54-201-88-203.us-west-2.compute.amazonaws.com
-```
-
-Once you have successfully signed-in, npm will automatically save new line to your .npmrc, saving your login token for the future.
-
-### Developer Workflow
-[to-do]
-- Travis CI
-- Linting/testing
-- Developer workflow
-- ?? (see current theme README for ideas)
-
-To work with and compile your Sass files on the fly start:
-
-- `$ gulp watch`
-
+### Contributing to the Theme
+Welcoming paragraph here with general contribution notes
+#### Coding Standards
+#### Code Linting
+##### Composer Scripts
+##### PHPCS
+#### Working with Styles
+To work with and compile your Sass files on the fly start:`$ gulp watch`
+#### BroswerSync
 Or, to run with Browser-Sync:
 
 - First change the browser-sync options to reflect your environment in the file `/gulpconfig.json` in the beginning of the file:
@@ -150,8 +138,13 @@ Or, to run with Browser-Sync:
 };
 ```
 - then run: `$ gulp watch-bs`
+#### Travis CI
 
-### Project Structure
+![divider](https://cdn.infonet.research.asu.edu/assets/divider.png)
+
+## Project Structure
+[is this needed?]
+
 This theme is built on top of [Understrap](https://understrap.com), with minor adjustments specific to the needs of the theme. Most traditional WordPress theme files are where you would expect them. Files and folders of interest include:
 
 | Name                            | Description                                                                |

--- a/README.md
+++ b/README.md
@@ -27,31 +27,44 @@
 
 ## ❯ Table of Contents
 
-- [Project Structure](#-project-structure)
-- [Getting Started](#-for-developers)
-- [Scripts and Tasks](#-scripts-and-tasks)
+- [❯ Table of Contents](#-table-of-contents)
+- [❯ Getting Started](#-getting-started)
+  - [Installing the Theme](#installing-the-theme)
+  - [Updating the Theme](#updating-the-theme)
+    - [Using Github Updater](#using-github-updater)
+  - [Using the Theme](#using-the-theme)
+- [❯ For Developers](#-for-developers)
+  - [Requirements](#requirements)
+  - [Local WordPress Environment](#local-wordpress-environment)
+    - [Local By Flywheel](#local-by-flywheel)
+    - [Lando](#lando)
+  - [Installing Dependencies](#installing-dependencies)
+  - [Installing Dependencies from the ASU Unity Design System](#installing-dependencies-from-the-asu-unity-design-system)
+    - [Creating a User Account and Saving your NPM Access Token](#creating-a-user-account-and-saving-your-npm-access-token)
+  - [Running](#running)
+  - [Project Structure](#project-structure)
+
 
 ![divider](https://cdn.infonet.research.asu.edu/assets/divider.png)
 
-## ❯ Project Structure
 
-This theme is built on top of [Understrap](https://understrap.com), with minor adjustments specific to the needs of the theme. Most traditional WordPress theme files are where you would expect them. Files and folders of interest include:
+## ❯ Getting Started
 
-| Name                            | Description                                                                |
-| ------------------------------- | -------------------------------------------------------------------------- |
-| **functions.php**               | A lean file that loads code from multiple files in the **/inc** directory  |
-| **/inc**                        | WordPress hooks and callbacks, organized by their purpose in the theme and loaded into **functions.php** at runtime     |
-| **/templates-loop**             | Partial templates for displaying content from posts and pages (the WordPress 'loop')                                     |
-| **/templates-page**  | Multiple full-page layout templates  |
-| **/templates-sidebar**          | Templates for the various widget areas in the theme (aka 'sidebars')    |
-| **/sass/theme/_theme**   | An SCSS file for styling rules that are not covered by the Bootstrap theme, or other SCSS files in the **/sass** directory. The first place to put your custom styles                                               |
+### Installing the Theme
+[to-do]
 
-![divider](https://cdn.infonet.research.asu.edu/assets/divider.png)
+### Updating the Theme
+[to-do]
+
+#### Using Github Updater
+[to-do]
+
+### Using the Theme
+[to-do]
 
 ## ❯ For Developers
 
-### Set up the Development Environment
-
+### Requirements
 You need to set up your development environment before you can do anything.
 
 Install [Node.js and NPM](https://nodejs.org/en/download/)
@@ -59,33 +72,36 @@ Install [Node.js and NPM](https://nodejs.org/en/download/)
 - on OSX use [homebrew](http://brew.sh) `brew install node`
 - on Windows use [chocolatey](https://chocolatey.org/) `choco install nodejs`
 
+### Local WordPress Environment
+This is a WordPress theme, and you will need to have access, and administrative rights, to a WordPress site in order to do any development on the theme. It is **not recommended** to attempt theme development on a live server.
 
-### Create a Local WordPress Development Environment
-This is a WordPress theme, and you will need to have access, and administrative rights, to a WordPress site in order to do any development on the theme. It is **not recommended** to attempt theme development on a live server. There are several solutions available for hosting local WordPress development sites on your own computer, including:
+There are several solutions available for hosting local WordPress development sites on your own computer, including:
 
 * [Local by Flywheel](https://localwp.com/)
 * [Lando](https://docs.lando.dev/)
 * [wp-local-docker](https://github.com/10up/wp-local-docker) by 10up
 * [VVV](https://varyingvagrantvagrants.org/)
 
-NOTE: As of 23 June 2020, the KE WordPress Theme Development Task Force (WP Power Rangers) are instructed to use [wp-local-docker](https://github.com/10up/wp-local-docker) by 10up. This framework has been pre-installed with [WP Snapshots](https://github.com/10up/wpsnapshots) a utility that allows us to capture file and database snapshots that will be pushed to an AWS S3 bucket, and allow us to restore our local development sites quickly and efficiently.
-
-#### Install and Configure wp-local-docker
-
-> TODO
-
 Once you have been able to install and run a local version of WordPress, clone this repository into the `wp-content/themes` folder and continue with the installation process below.
 
-#### Using WP Snapshots to Push/Pull website snapshots
+#### Local By Flywheel
+[to-do-local-setup]
 
-> TODO
+#### Lando
+[to-do-lando-setup]
 
-### A Note on Installing Dependencies from the ASU Unity Design System Package Repository ###
+### Installing Dependencies
+- Make sure you have installed Node.js and Browser-Sync (optional) on your computer globally
+- Then open your terminal and browse to the location of the theme
+- Run: `$ composer install`
+- Run: `$ npm install`
+
+### Installing Dependencies from the ASU Unity Design System
 The ASU-produced packages in this theme are loaded from the ASU Unity Private NPM (Verdaccio) package repository. This requires you to sign-in and create a user account on the NPM server. Doing so, npm will automatically save your authentication token into a local .npmrc file located in your home directory.
 
 #### Creating a User Account and Saving your NPM Access Token
 1. Visit the ASU Unity NPM Package server and follow directions to add yourself as a user: http://ec2-54-201-88-203.us-west-2.compute.amazonaws.com/
-2. Configure npm to use this private registry. Add the following line to the .npmrc file in my home directory (existing lines can be left in-place):
+2. Configure npm to use this private registry. Add the following line to the .npmrc file in your home directory (existing lines can be left in-place):
 
 ```
 @asu-design-system:registry=http://ec2-54-201-88-203.us-west-2.compute.amazonaws.com
@@ -98,12 +114,6 @@ npm login --registry http://ec2-54-201-88-203.us-west-2.compute.amazonaws.com
 ```
 
 Once you have successfully signed-in, npm will automatically save new line to your .npmrc, saving your login token for the future.
-
-### Installing Dependencies
-- Make sure you have installed Node.js and Browser-Sync (optional) on your computer globally
-- Then open your terminal and browse to the location of the theme
-- Run: `$ composer install`
-- Run: `$ npm install`
 
 ### Running
 To work with and compile your Sass files on the fly start:
@@ -124,11 +134,14 @@ Or, to run with Browser-Sync:
 ```
 - then run: `$ gulp watch-bs`
 
-## ❯ For Theme Users
+### Project Structure
+This theme is built on top of [Understrap](https://understrap.com), with minor adjustments specific to the needs of the theme. Most traditional WordPress theme files are where you would expect them. Files and folders of interest include:
 
-### How to Use the Built-In Widget Slider
-
-The front-page slider is widget driven. Simply add more than one widget to widget position “Hero”.
-- Click on Appearance → Widgets.
-- Add two, or more, widgets of any kind to widget area “Hero”.
-- That’s it.
+| Name                            | Description                                                                |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| **functions.php**               | A lean file that loads code from multiple files in the **/inc** directory  |
+| **/inc**                        | WordPress hooks and callbacks, organized by their purpose in the theme and loaded into **functions.php** at runtime     |
+| **/templates-loop**             | Partial templates for displaying content from posts and pages (the WordPress 'loop')                                     |
+| **/templates-page**  | Multiple full-page layout templates  |
+| **/templates-sidebar**          | Templates for the various widget areas in the theme (aka 'sidebars')    |
+| **/sass/theme/_theme**   | An SCSS file for styling rules that are not covered by the Bootstrap theme, or other SCSS files in the **/sass** directory. The first place to put your custom styles                                               |


### PR DESCRIPTION
Resolves #34 

An initial restructuring of the `readme.md` file focusing on creating an overall structure with two main areas: one for end users, and one for developers/contributors. This is just a first step towards a new readme, but I wanted to get it folded into develop so that others could start contributing.

- Contains a proposed structure for the file
- Functional table of contents with working links
- Some previous content left in place for review

I am having it 'resolve' #34 as that issue was a test issue Bryan created, and so we can create a batch of new tasks in the documentation project for the readme.