### PR TITLE
Deleted bg-transparent class from the search button

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 		<input class="field form-control border-right-0 rounded-0" id="s" name="s" type="text"
 			placeholder="<?php esc_attr_e( 'Search', 'uds-wordpress-theme' ); ?>" value="<?php the_search_query(); ?>">
 			<span class="input-group-append">
-			<button class="submit bg-transparent form-control border-left-0 rounded-0" id="searchsubmit" name="submit" type="submit"> <i class="fa fa-search"></i></button>
+			<button class="submit form-control border-left-0 rounded-0" id="searchsubmit" name="submit" type="submit"> <i class="fa fa-search"></i></button>
 			</span>
 	</div>
 </form>


### PR DESCRIPTION
I noticed that the bootstrap class "bg-transparent" was added to the search button which gives it a transparent background. 
I only removed the class from there so that when we add a background to the 404 page, the search bar will be displayed all as one bar including the search button, instead of having the search button looks separate when the transparent background is applied.

