### PR TITLE
Added a checkbox to have the option to hide page title

### DIFF
--- a/acf-json/group_60074496e95ba.json
+++ b/acf-json/group_60074496e95ba.json
@@ -1,0 +1,50 @@
+{
+    "key": "group_60074496e95ba",
+    "title": "Page title",
+    "fields": [
+        {
+            "key": "field_6007449f54b72",
+            "label": "Hide page title",
+            "name": "hide_page_title",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "page"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "side",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1611089113
+}

--- a/templates-global/hero.php
+++ b/templates-global/hero.php
@@ -63,7 +63,8 @@ if ( ! empty( $hero_asset_url ) ) :
 else :
 
 	echo '<section id="page-title"><div class="container"><div class="row"><div class="col-md-12">';
-	the_title( '<h1 class="entry-title">', '</h1>' );
+	if ( ! get_field( 'hide_page_title' ) ) {
+		the_title( '<h1 class="entry-title">', '</h1>' ); }
 	echo '</div></div></div></section>';
 
 endif;

--- a/templates-loop/content-single.php
+++ b/templates-loop/content-single.php
@@ -13,7 +13,10 @@ defined( 'ABSPATH' ) || exit;
 
 	<header class="entry-header">
 
-		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+		<?php 
+		if ( ! get_field( 'hide_page_title' ) ) {
+			the_title( '<h1 class="entry-title">', '</h1>' );} 
+		?>
 
 		<div class="entry-meta">
 


### PR DESCRIPTION
 I noticed that we need to have the option to hide page title in case if page title has to be styled like the ones in Devils drop off website.
I had to remove the page title and add a regular Heading block to create a styled title. But the issue was that the pages would show with no title in the editor, and we can't tell which is which: 
 
![Screen Shot 2021-01-19 at 1 57 48 PM](https://user-images.githubusercontent.com/15880606/105092364-5c7c2e80-5a5e-11eb-8546-b2bf99e2446d.png)

To solve this issue:
- I created a True/False field in ACF.
- Added an if condition before printing the page title in **hero.php** template and **content-single.php**. 
- This feature will be added to post and page types. 

![Screen Shot 2021-01-19 at 2 03 04 PM](https://user-images.githubusercontent.com/15880606/105092884-12477d00-5a5f-11eb-96cb-bced7a1d5916.png)

