### PR TITLE
Adjust display none property of the "home" text in the mobile menu.

### DIFF
--- a/inc/render-partials.php
+++ b/inc/render-partials.php
@@ -145,7 +145,7 @@ function uds_wp_render_main_nav_menu() {
 		?>
 
 		<a class="nav-link <?php echo $home_icon_class; ?>" href="<?php echo esc_url( home_url() ); ?>">
-			<span class="d-lg-none">Home</span>
+			<span class="d-xl-none">Home</span>
 			<span title="Home" class="fas fa-fw fa-home"></span>
 		</a>
 


### PR DESCRIPTION
Fixes #80. 

A one-line fix within `render-partials.php` addressed the breakpoint at which the word "Home" appears in the mobile menu. Recommended fix from UDS-332 from the unity project. https://github.com/ASU/asu-unity-stack/pull/96