### PR TITLE
Replace Dummy Links in Header

### DIFF
--- a/header.php
+++ b/header.php
@@ -113,7 +113,7 @@ if ( ! empty( $c_options['hotjar_site_id'] ) ) {
 							<a class="nav-link" href="https://my.asu.edu">My ASU</a>
 							<a class="nav-link" href="https://asu.edu/about/colleges-and-schools">Colleges and Schools</a>
 							<div class="nav-link login-status">
-								<a class="signin" href="#">Sign In</a>
+								<a class="signin" href="https://my.asu.edu">Sign In</a>
 							</div>
 							<form class="form-inline" action="https://search.asu.edu/search" method="get" name="gs">
 								<input class="form-control" type="search" name="q" aria-labelledby="header-top-search" required>
@@ -138,7 +138,7 @@ if ( ! empty( $c_options['hotjar_site_id'] ) ) {
 					<div id="header-main" class="col-12">
 						<nav class="navbar navbar-expand-xl" aria-label="Main">
 
-							<a class="navbar-brand" href="#">
+							<a class="navbar-brand" href="https://www.asu.edu">
 								<img class="vert" src="<?php echo get_template_directory_uri(); ?>/img/logo/asu_university_vert_maroongold.png" alt="Arizona State University" />
 								<img class="horiz" src="<?php echo get_template_directory_uri(); ?>/img/logo/asu_university_horiz_maroongold.png" alt="Arizona State University" />
 							</a>


### PR DESCRIPTION
Replacing two placeholder links in `header.php` that were just links to the top of the page. Suggested changes are:

* Update the main ASU logo in the header to link to 'https://www.asu.edu'
* Update the 'Sign In' link in the global menu bar to link to 'https://my.asu.edu'

We have been asked if the 'Sign In' link could also pass users through to the WordPress site, but that will require some investigation. This fix at least means that an unauthorized user who clicks on 'Sign In' will be logged in to their ASU account via CAS - which is the real purpose of that link.