### PR TITLE
Deleted browserSyncOptions.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To work with and compile your Sass files on the fly start:`$ gulp watch`
 
 Or, to run with Browser-Sync:
 
-- First change the browser-sync options to reflect your environment in the file `/gulpconfig.json` in the beginning of the file:
+- First create a new .json file in the theme root, name it "browserSyncOptions.json", copy and paste the lines below into the new created file:
 
 ```javascript
 {
@@ -267,7 +267,7 @@ Or, to run with Browser-Sync:
     ...
 };
 ```
-
+- Change the browser-sync options to reflect your environment in the file `/browserSyncOptions.json` in the beginning of the file:
 - then run: `$ gulp watch-bs`
 
 #### Travis CI

--- a/browserSyncOptions.json
+++ b/browserSyncOptions.json
@@ -1,7 +1,0 @@
-{
-	"browserSyncOptions": {
-		"proxy": "localhost:8080/",
-		"notify": false,
-		"files": ["./css/*.min.css", "./js/*.min.js", "./**/*.php"]
-	}
-}


### PR DESCRIPTION
I deleted the browserSyncOptions.json file to prevent it from being tracked by git, it was added to gitignore previously. 
I also updated the readme file, added a new step to create browserSyncOptions.json file and put your browser sync options in there. 

Files I changed: 

- Deleted browserSyncOptions.json. 
- Updated README.md
