### PR TITLE
Add Named Anchors to Headings

### DIFF
--- a/acf-json/group_601dab5fa164e.json
+++ b/acf-json/group_601dab5fa164e.json
@@ -114,6 +114,25 @@
             "ui": 1,
             "ui_on_text": "",
             "ui_off_text": ""
+        },
+        {
+            "key": "field_60625cab68b39",
+            "label": "Anchor",
+            "name": "uds_heading_anchor_text",
+            "type": "text",
+            "instructions": "Enter an ID, without any spaces, for this header. This will allow direct links to this header.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "anchor-name",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
         }
     ],
     "location": [
@@ -129,9 +148,9 @@
     "position": "normal",
     "style": "default",
     "label_placement": "top",
-    "instruction_placement": "label",
+    "instruction_placement": "field",
     "hide_on_screen": "",
     "active": true,
     "description": "Fields for creating UDS compliant header tags, with customizable text and highlight colors.",
-    "modified": 1616200454
+    "modified": 1617062194
 }

--- a/templates-blocks/headings/headings.php
+++ b/templates-blocks/headings/headings.php
@@ -16,8 +16,8 @@
 
  // If additional classes were requested, add them.
 $additional_classes = '';
-if ( ! empty( $block['className'] ) ) {
-	$additional_classes = sanitize_text_field( $block['className'] );
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+	$additional_classes = 'class="' . trim ( sanitize_text_field( $block['className'] ) ) . '"';
 }
 
 // If the 'smaller size' checkbox was checked, add the 'article' class.
@@ -30,10 +30,17 @@ if ( get_field( 'uds_heading_add_spacing' ) ) {
 	$additional_classes .= ' mt-6';
 }
 
+// Build text for an ID, if text for a named anchor was provided.
+$anchor_text = '';
+if( get_field( 'uds_heading_anchor_text' ) ) {
+	$anchor_text = 'id="' . sanitize_text_field( get_field( 'uds_heading_anchor_text' ) ) . '"';
+}
+
 // Setup our variables.
-$start_tag = '<h' . get_field( 'level' ) . ' class="' . trim( $additional_classes ) . '" >';
+$start_tag = '<h' . get_field( 'level' ) . ' ' . $anchor_text . trim( $additional_classes ) . '>';
 $end_tag = '</h' . get_field( 'level' ) . '>';
 $highlight_class = get_field( 'text_highlight' );
+$named_anchor_text = get_field( 'uds_heading_anchor_text' );
 
 // Dont use highlight class if none is selected.
 if ( 'none' == $highlight_class ) {

--- a/templates-blocks/headings/headings.php
+++ b/templates-blocks/headings/headings.php
@@ -14,42 +14,53 @@
  * highlights are applied to the inner <span> tag.
  */
 
- // If additional classes were requested, add them.
-$additional_classes = '';
+ // If additional classes were requested, clean up the input and add them.
+$additional_classes = array();
 if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
-	$additional_classes = 'class="' . trim ( sanitize_text_field( $block['className'] ) ) . '"';
+	// $additional_classes = 'class="' . trim ( sanitize_text_field( $block['className'] ) ) . '"';
+	array_push( $additional_classes, trim( sanitize_text_field( $block['className'] ) ) );
 }
 
 // If the 'smaller size' checkbox was checked, add the 'article' class.
 if ( get_field( 'smaller_size' ) ) {
-	$additional_classes .= ' article';
+	// $additional_classes .= ' article';
+	array_push( $additional_classes, 'article' );
 }
 
 // If 'extra space' was requested, add 3rem (mt-6) to the top of this header.
 if ( get_field( 'uds_heading_add_spacing' ) ) {
-	$additional_classes .= ' mt-6';
+	// $additional_classes .= ' mt-6';
+	array_push( $additional_classes, 'mt-6' );
+}
+
+// make a string out of our additional classes, if any were provided.
+if ( ! empty( $additional_classes ) ) {
+	$additional_classes_text = 'class="' . implode( ' ', $additional_classes ) . '"';
+} else {
+	$additional_classes_text = '';
 }
 
 // Build text for an ID, if text for a named anchor was provided.
 $anchor_text = '';
-if( get_field( 'uds_heading_anchor_text' ) ) {
+if ( get_field( 'uds_heading_anchor_text' ) ) {
 	$anchor_text = 'id="' . sanitize_text_field( get_field( 'uds_heading_anchor_text' ) ) . '"';
 }
 
 // Setup our variables.
-$start_tag = '<h' . get_field( 'level' ) . ' ' . $anchor_text . trim( $additional_classes ) . '>';
+$start_tag = '<h' . get_field( 'level' ) . ' ' . $anchor_text . ' ' . $additional_classes_text . '>';
 $end_tag = '</h' . get_field( 'level' ) . '>';
 $highlight_class = get_field( 'text_highlight' );
 $named_anchor_text = get_field( 'uds_heading_anchor_text' );
 
-// Dont use highlight class if none is selected.
-if ( 'none' == $highlight_class ) {
-	$highlight_class = '';
+// Create the highlight class text if a highlight color was chosen.
+$highlight_text = '';
+if ( 'none' !== $highlight_class ) {
+	$highlight_text = 'class="' . $highlight_class . '"';
 }
 
 // Sanitize header text field.
 $header_text = sanitize_text_field( get_field( 'text' ) );
 
 // Construct the heading tag.
-echo $start_tag . ' <span class="' . $highlight_class . '">' . $header_text . '</span>' . $end_tag;
+echo $start_tag . ' <span ' . $highlight_text . '>' . $header_text . '</span>' . $end_tag;
 ?>


### PR DESCRIPTION
Adds a new field to the Heading field group, and corresponding code in the template, to implement named anchors in our UDS Heading block. Users can enter an anchor name for a heading, and that name will be used as the heading's ID.

Changes proposed in this pull request:

- Add new named anchor field to the field group
- Update the code to render an ID on headings if an anchor name was provided
- Changed the way we apply 'additional classes' to build an array, and then 'implode' it into a string once all additional classes have been evaluated.
