### PR TITLE
Fix anchor issues with tabs and accordion

### DIFF
--- a/inc/scroll-to-div.php
+++ b/inc/scroll-to-div.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'scroll_to_div' ) ) {
 		 menu.on('click', function(event) {
 			var target = jQuery(this.getAttribute('href'));
 
-			if( target.length ) {
+			if( (target.length) && (0 != target.offset().top) ) {
 				event.preventDefault();
 					jQuery('html, body').stop().animate({
 						scrollTop: target.offset().top - 150


### PR DESCRIPTION
I updated the jq code to fix the issue with anchor links on tabs and accordion. 
added the line to if statement: 
`(0 != target.offset().top)`
