### PR TITLE
Remove margin form entry-footer section

### DIFF
--- a/page.php
+++ b/page.php
@@ -29,7 +29,7 @@ get_header();
 			the_content();
 
 			// Display the edit post button to logged in users.
-			echo '<footer class="entry-footer"><div class="container mb-2"><div class="row"><div class="col-md-12">';
+			echo '<footer class="entry-footer"><div class="container"><div class="row"><div class="col-md-12">';
 			edit_post_link( __( 'Edit', 'uds-wordpress-theme' ), '<span class="edit-link">', '</span>' );
 			echo '</div></div></div></footer><!-- end .entry-footer -->';
 		}


### PR DESCRIPTION
I removed the mb-2 class from the container div in entry footer section to remove that extra margin that would appear when we're logged out of wp-admin. 

![image](https://user-images.githubusercontent.com/15880606/113759746-4af40b80-96ca-11eb-9905-10ff64283750.png)

