### PR TITLE
Add Alt Tag to Card Images

### DIFF
--- a/acf-json/group_602edd7eb0e61.json
+++ b/acf-json/group_602edd7eb0e61.json
@@ -145,7 +145,7 @@
                 "class": "",
                 "id": ""
             },
-            "return_format": "url",
+            "return_format": "array",
             "preview_size": "thumbnail",
             "library": "all",
             "min_width": "",
@@ -585,5 +585,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "Fields for creating static, but customizable, versions of all UDS card types: standard, story, degree, and event.",
-    "modified": 1616188270
+    "modified": 1618008714
 }

--- a/templates-blocks/cards/card.php
+++ b/templates-blocks/cards/card.php
@@ -69,12 +69,20 @@ if ( ! empty( get_field( 'hover' ) ) ) {
 }
 
 // Get our image data from the array provided by ACF.
+$image_url = '';
+$image_alt = '';
+
 $image_data = get_field( 'image' );
+
+if ( ! empty( $image_data ) ) {
+	$image_url = $image_data['url'];
+	$image_alt = $image_data['alt'];
+}
 ?>
 
 <div class="card <?php echo $style_class; ?> <?php echo $orientation_class; ?> <?php echo $additional_classes; ?> <?php echo $hover_class; ?>">
 	<?php if ( 'image' == $header_style ) : ?>
-		<img class="card-img-top" src="<?php echo $image_data['url']; ?>" alt="<?php echo $image_data['alt']; ?>">
+		<img class="card-img-top" src="<?php echo $image_url; ?>" alt="<?php echo $image_alt; ?>">
 	<?php endif; ?>
 	<?php if ( 'icon' == $header_style ) : ?>
 		<i class="fas fa-<?php echo $icon_name; ?> fa-2x card-icon-top"></i>

--- a/templates-blocks/cards/card.php
+++ b/templates-blocks/cards/card.php
@@ -67,11 +67,14 @@ $hover_class = '';
 if ( ! empty( get_field( 'hover' ) ) ) {
 	$hover_class = 'card-hover';
 }
+
+// Get our image data from the array provided by ACF.
+$image_data = get_field( 'image' );
 ?>
 
 <div class="card <?php echo $style_class; ?> <?php echo $orientation_class; ?> <?php echo $additional_classes; ?> <?php echo $hover_class; ?>">
 	<?php if ( 'image' == $header_style ) : ?>
-		<img class="card-img-top" src="<?php the_field( 'image' ); ?>" alt="Card image cap">
+		<img class="card-img-top" src="<?php echo $image_data['url']; ?>" alt="<?php echo $image_data['alt']; ?>">
 	<?php endif; ?>
 	<?php if ( 'icon' == $header_style ) : ?>
 		<i class="fas fa-<?php echo $icon_name; ?> fa-2x card-icon-top"></i>


### PR DESCRIPTION
Resolves #162 

Images on cards still had a hard-coded placeholder for the `alt` tag, so we needed to retrieve that value and add it to the markup.

Changes proposed in this pull request:

- Change the 'image' field in the ACF group to return an array of data, and not just the image URL
- Update the code to retrieve both the image URL and the `alt` text from that array, and use those values when building card images.
