### PR TITLE
Fix addEventListener of null error on video hero

### DIFF
--- a/js/hero_video.js
+++ b/js/hero_video.js
@@ -10,6 +10,8 @@
 	 //Get the hero video ID.
 	var HeroVid = document.getElementById( 'media-video' );
 
+if ( HeroVid ) {
+
 //When play button is clicked
 	document.getElementById( 'playHeroVid' ).addEventListener( 'click', function() {
 	    HeroVid.play();
@@ -24,6 +26,8 @@
 			$( this ).hide();
 			$( '#playHeroVid' ).show();
 	});
+}
+
 /*
 //When space key is clicked
 	$( window ).keypress(function( e ) {


### PR DESCRIPTION
updated hero_video.js to only run when there is a video to avoid getting the error: 
`'Uncaught TypeError: Cannot read property 'addEventListener' of null'`