### PR TITLE
Allow Customized Unit Name Text in Footer

### DIFF
--- a/inc/customizer/customizer-settings.php
+++ b/inc/customizer/customizer-settings.php
@@ -525,6 +525,91 @@ if ( ! function_exists( 'uds_wp_register_theme_customizer_settings' ) ) {
 			)
 		);
 
+
+		/**
+		* Footer Alternate Unit Name Text
+		*/
+		$wp_customize->add_setting(
+			'footer_unit_name_type',
+			array(
+				'default'           => 'default',
+				'capability'        => 'edit_theme_options',
+				'type'              => 'theme_mod',
+				'sanitize_callback' => 'uds_wp_sanitize_nothing',
+				'transport'         => 'postMessage',
+			)
+		);
+
+		$wp_customize->add_control(
+			'footer_unit_name_type',
+			array(
+				'label'      => __( 'Footer Unit Name Type', 'uds-wordpress-theme' ),
+				'description'       => __(
+					'<p>Choose between using the site name, or custom text, beneath the footer logo.</p>',
+					'uds-wordpress-theme'
+				),
+				'section'    => 'uds_wp_theme_section_footer',
+				'settings'   => 'footer_unit_name_type',
+				'type'       => 'radio',
+				'choices'    => array(
+					'default'  => 'Site Name',
+					'custom' => 'Custom Text',
+				),
+				'priority'   => 60,
+			)
+		);
+
+		$wp_customize->selective_refresh->add_partial(
+			'footer_unit_name_type',
+			array(
+				'selector'            => '#footer-unit-text',
+				'container_inclusive' => false,
+				'render_callback' => function() {
+					return (
+						uds_wp_render_footer_unit_name()
+					);
+				},
+			)
+		);
+
+		/**
+		 * Footer alternate unit name value
+		 */
+		$wp_customize->add_setting(
+			'footer_unit_name_text',
+			array(
+				'default'           => '',
+				'capability'        => 'edit_theme_options',
+				'type'              => 'theme_mod',
+				'sanitize_callback' => 'uds_wp_sanitize_nothing',
+				'transport'         => 'postMessage',
+			)
+		);
+
+		$wp_customize->add_control(
+			'footer_unit_name_text',
+			array(
+				'label'      => __( 'Alternate Text', 'uds-wordpress-theme' ),
+				'description'       => __(
+					'Text to use, instead of the site name, beneath the footer logo',
+					'uds-wordpress-theme'
+				),
+				'section'    => 'uds_wp_theme_section_footer',
+				'settings'   => 'footer_unit_name_text',
+				'active_callback' => 'show_alternate_footer_title_input',
+				'priority'   => 70,
+			)
+		);
+
+		$wp_customize->selective_refresh->add_partial(
+			'footer_unit_name_text',
+			array(
+				'selector' => '#footer-unit-text',
+				'container_inclusive' => false,
+				'render_callback' => 'uds_wp_render_footer_unit_name',
+			)
+		);
+
 		/**
 		 * Contribute URL
 		 */
@@ -818,6 +903,24 @@ function show_custom_logo_fields() {
 	if ( 'asu' === $logo_type ) {
 		return false;
 	} else {
+		return true;
+	}
+}
+
+/**
+ * Show or hide a text input for entering alternate text to replace the site
+ * name beneath the unit logo in the footer. If the user has selected 'custom',
+ * for the unit text type, we want to show this field.
+ */
+function show_alternate_footer_title_input() {
+
+	return true;
+
+	$footer_unit_name_type = get_theme_mod( 'footer_unit_name_type' );
+
+	if( 'default' === $footer_unit_name_type ){
+		return false;
+	}else{
 		return true;
 	}
 }

--- a/inc/customizer/customizer-settings.php
+++ b/inc/customizer/customizer-settings.php
@@ -918,9 +918,9 @@ function show_alternate_footer_title_input() {
 
 	$footer_unit_name_type = get_theme_mod( 'footer_unit_name_type' );
 
-	if( 'default' === $footer_unit_name_type ){
+	if ( 'default' === $footer_unit_name_type ) {
 		return false;
-	}else{
+	} else {
 		return true;
 	}
 }

--- a/inc/render-partials.php
+++ b/inc/render-partials.php
@@ -315,7 +315,7 @@ function uds_wp_render_footer_action_row() {
 				<div class="row">
 
 					<div class="col-xl-3" id="info-column">
-						<h5><span class="footer-site-name"><?php echo get_bloginfo( 'name' ); ?></span></h5>
+						<h5><span class="footer-site-name" id="footer-unit-text"><?php uds_wp_render_footer_unit_name(); ?></span></h5>
 						<div class="contact-wrapper">
 							<?php uds_wp_render_contact_link(); ?>
 						</div>
@@ -347,4 +347,18 @@ function uds_wp_render_asu_footer_logo() {
 		),
 		wp_kses_allowed_html( 'post' )
 	);
+}
+
+/**
+ * Renders text below the footer logo: either the site name, or some custom text.
+ */
+function uds_wp_render_footer_unit_name() {
+	$footer_unit_name_type = get_theme_mod( 'footer_unit_name_type' );
+
+	if( 'custom' === $footer_unit_name_type) {
+		$footer_unit_name_text = get_theme_mod( 'footer_unit_name_text' );
+		echo $footer_unit_name_text;
+	} else {
+		echo get_bloginfo( 'name' );
+	}
 }

--- a/inc/render-partials.php
+++ b/inc/render-partials.php
@@ -355,7 +355,7 @@ function uds_wp_render_asu_footer_logo() {
 function uds_wp_render_footer_unit_name() {
 	$footer_unit_name_type = get_theme_mod( 'footer_unit_name_type' );
 
-	if( 'custom' === $footer_unit_name_type) {
+	if ( 'custom' === $footer_unit_name_type ) {
 		$footer_unit_name_text = get_theme_mod( 'footer_unit_name_text' );
 		echo $footer_unit_name_text;
 	} else {

--- a/inc/theme-settings.php
+++ b/inc/theme-settings.php
@@ -39,6 +39,7 @@ if ( ! function_exists( 'uds_wp_get_theme_default_settings' ) ) {
 			'sitename_as_link'       => false, // default to the site title being plain text, NOT a link.
 			'footer_logo_type'       => 'asu', // default to the ASU logo. See img/unit-logos.json for options.
 			'logo_select'            => 'none', // default the endorsed logo drop-down to none.
+			'footer_unit_name_type'  => 'default', // default to setting the site name as the text below footer logo.
 			'footer_row_actions'     => 'enabled', // default to having the logo/social row in the footer enabled.
 			'footer_row_branding'    => 'enabled', // default to having the menu row in the footer enabled.
 			'header_navigation_menu' => 'enabled', // enable main nav menu by default.

--- a/js/customizer-controls.js
+++ b/js/customizer-controls.js
@@ -51,7 +51,10 @@
 		var linkSettingValueToControl;
 
 		/**
-		 * Update other controls' states according to footer_logo_type's value
+		 * Show/hide footer text input based on value of radio controls.
+		 * When 'footer_unit_name_type' control is changed, we check to
+		 * see if it is set to 'default'. If so, we hide the text input.
+		 * If not, it must be 'custom', and we show the input.
 		 *
 		 * @param {api.Control} control the footer_unit_name_type control.
 		 */

--- a/js/customizer-controls.js
+++ b/js/customizer-controls.js
@@ -44,4 +44,35 @@
 		api.control( 'logo_url', linkSettingValueToControl );
 	} );
 
+	/**
+	 *
+	 */
+	 api( 'footer_unit_name_type', function( setting ) {
+		var linkSettingValueToControl;
+
+		/**
+		 * Update other controls' states according to footer_logo_type's value
+		 *
+		 * @param {api.Control} control the footer_unit_name_type control.
+		 */
+		linkSettingValueToControl = function( control ) {
+			var visibility = function() {
+				if ( 'default' === setting.get() ) {
+					control.container.slideUp( 180 );
+				} else {
+					control.container.slideDown( 180 );
+				}
+			};
+
+			// Set initial active state.
+			visibility();
+
+			//Update activate state whenever the setting is changed.
+			setting.bind( visibility );
+		};
+
+		// Call linkSettingValueToControl on our drop-down and URL fields.
+		api.control( 'footer_unit_name_text', linkSettingValueToControl );
+	} );
+
 }( wp.customize ) );


### PR DESCRIPTION
Our current customizer and footer code simply repeats the site name beneath the logo in the ASU global footer. This was based on existing XD/Storybook examples, and is probably the 'correct' thing, but does not allow for the customization that our clients need. This PR updates both the Customizer and our footer code to allow for customized text in the footer.


**Changes proposed in this pull request:**
- Add two new settings for the Customizer:
  - `footer_unit_name_type`: for storing the choice between using the unit name, or custom text
  - `footer_unit_name_text`: for storing the custom text
- Add a new control in the Customizer to allow users to choose between repeating the site name, or entering customized text, for the footer text just below the logo
- Add a new control, hidden by default, for entering custom text. This field shows/hides itself based on the user's choice in the first field
- Updated logic in the footer file that checks the value of the first field and displays either the site name, or the custom text, based on the current setting


**Example Screenshot**:

<img width="834" alt="Screen Shot 2021-05-03 at 3 20 47 PM" src="https://user-images.githubusercontent.com/31013359/116944030-892d0e00-ac29-11eb-8f76-b2b6555d79e1.png">

