### PR TITLE
Fix PHP Warnings on Additional Classes

### DIFF
--- a/templates-blocks/blockquote/blockquote.php
+++ b/templates-blocks/blockquote/blockquote.php
@@ -79,9 +79,10 @@ if ( $image ) {
 	}
 }
 
-// Retrieve additional classes from the 'advanced' field in the editor.
-if ( ! empty( $block['className'] ) ) {
-	$additional_classes = $block['className'];
+// If additional classes were requested, clean up the input and add them.
+$additional_classes = '';
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+	$additional_classes = trim( sanitize_text_field( $block['className'] ) );
 }
 ?>
 

--- a/templates-blocks/button/button.php
+++ b/templates-blocks/button/button.php
@@ -63,10 +63,12 @@ if ( get_field( 'icon' ) ) {
 	$icon_span = '';
 }
 
-// Retrieve additional classes from the 'advanced' field in the editor.
-if ( ! empty( $block['className'] ) ) {
-	$additional_classes = sanitize_text_field( $block['className'] );
+// If additional classes were requested, clean up the input and add them.
+$additional_classes = '';
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+	$additional_classes = trim( sanitize_text_field( $block['className'] ) );
 }
+
 
 ?>
 

--- a/templates-blocks/cards/card.php
+++ b/templates-blocks/cards/card.php
@@ -57,9 +57,10 @@ if ( 'icon' == $header_style && '' != $icon_name ) {
 	$icon_name = sanitize_text_field( $icon_name );
 }
 
-// Retrieve additional classes from the 'advanced' field in the editor.
-if ( ! empty( $block['className'] ) ) {
-	$additional_classes = sanitize_text_field( $block['className'] );
+// If additional classes were requested, clean up the input and add them.
+$additional_classes = '';
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+	$additional_classes = trim( sanitize_text_field( $block['className'] ) );
 }
 
 // Check for the 'hover' variant, and set the class if needed.

--- a/templates-blocks/content-sections/image-overlap.php
+++ b/templates-blocks/content-sections/image-overlap.php
@@ -13,9 +13,10 @@ if ( ! $background ) {
 	$background['alt'] = 'A placeholder image';
 }
 
-// Retrieve additional classes from the 'advanced' field in the editor.
-if ( ! empty( $block['className'] ) ) {
-	$additional_classes = sanitize_text_field( $block['className'] );
+// If additional classes were requested, clean up the input and add them.
+$additional_classes = '';
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+	$additional_classes = trim( sanitize_text_field( $block['className'] ) );
 }
 
 // Determine if the content is on the left, or the right.

--- a/templates-blocks/overlay-card/overlay-card.php
+++ b/templates-blocks/overlay-card/overlay-card.php
@@ -33,9 +33,11 @@ if ( ! $hover_image ) {
 	$hover_image = array(
 		'url' => 'https://thesundevils.com/common/controls/image_handler.aspx?thumb_id=0&image_path=/images/2020/4/27/ASU_Sun_Devil_Athetics_Video_Background_76.jpg',
 	);}
+
+// If additional classes were requested, clean up the input and add them.
 $additional_classes = '';
-if ( ! empty( $block['className'] ) ) {
-	$additional_classes = $block['className'];
+if ( isset( $block['className'] ) && ! empty( $block['className'] ) ) {
+	$additional_classes = trim( sanitize_text_field( $block['className'] ) );
 }
 
 ?>


### PR DESCRIPTION
Some of our ACF blocks were throwing warnings about uninitialized variables with regard to retrieving the additional CSS classes from the `advanced` area of the Gutenberg editor. It turns out that I had copied/pasted the wrong bit of code to multiple blocks and left out the line that was initializing the variable used to hold those additional class names.

The following blocks were updated with this new code:

- Blockquote
- Button
- Card
- Content/Image Overlap
- Program (aka 'overlay') Cards

This was a code-only change, and **does not** require any re-syncing of  ACF field information. Changes proposed in this pull request:

- Update the code in all blocks that were not up to date already. The new code not only initializes the variable, but also includes sanitizing the input, and trimming off any extraneous whitespace.

