### PR TITLE
Automatically sync ACF JSON files upon hitting the admin screen.

### DIFF
--- a/inc/uds-blocks.php
+++ b/inc/uds-blocks.php
@@ -146,8 +146,8 @@ function uds_sync_acf_fields_with_json() {
 		$modified = acf_maybe_get( $group, 'modified', 0 );
 		$private  = acf_maybe_get( $group, 'private', false );
 
-		if ( $local !== 'json' || $private ) {
-			// ignore DB / PHP / private field groups
+		if ( 'json' !== $local || $private ) {
+			// ignore DB / PHP / private field groups.
 			continue;
 		}
 
@@ -170,4 +170,4 @@ function uds_sync_acf_fields_with_json() {
 		acf_import_field_group( $sync[ $key ] );
 	}
 }
-add_action( 'admin_init', 'uds_sync_acf_fields_with_json');
+add_action( 'admin_init', 'uds_sync_acf_fields_with_json' );

--- a/inc/uds-blocks.php
+++ b/inc/uds-blocks.php
@@ -117,3 +117,57 @@ if ( ! function_exists( 'remove_core_patterns' ) ) {
 	}
 	add_action( 'after_setup_theme', 'remove_core_patterns' );
 }
+
+/**
+ * Automatically sync any JSON field configuration.
+ * Courtesy of Delicious Brains and a developer blog post:
+ * https://gist.github.com/polevaultweb/32056461d1e4b85426211d2e5f85a3eb
+ * https://deliciousbrains.com/advanced-custom-fields-wordpress/
+ */
+function uds_sync_acf_fields_with_json() {
+	if ( defined( 'DOING_AJAX' ) || defined( 'DOING_CRON' ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'acf_get_field_groups' ) ) {
+		return;
+	}
+
+	$groups = acf_get_field_groups();
+
+	if ( empty( $groups ) ) {
+		return;
+	}
+
+	$sync = array();
+
+	foreach ( $groups as $group ) {
+		$local    = acf_maybe_get( $group, 'local', false );
+		$modified = acf_maybe_get( $group, 'modified', 0 );
+		$private  = acf_maybe_get( $group, 'private', false );
+
+		if ( $local !== 'json' || $private ) {
+			// ignore DB / PHP / private field groups
+			continue;
+		}
+
+		if ( ! $group['ID'] ) {
+			$sync[ $group['key'] ] = $group;
+		} elseif ( $modified && $modified > get_post_modified_time( 'U', true, $group['ID'], true ) ) {
+			$sync[ $group['key'] ] = $group;
+		}
+	}
+
+	if ( empty( $sync ) ) {
+		return;
+	}
+
+	foreach ( $sync as $key => $v ) {
+		if ( acf_have_local_fields( $key ) ) {
+			$sync[ $key ]['fields'] = acf_get_local_fields( $key );
+		}
+
+		acf_import_field_group( $sync[ $key ] );
+	}
+}
+add_action( 'admin_init', 'uds_sync_acf_fields_with_json');


### PR DESCRIPTION
Adds a function to the `functions.php` stack to automatically sync any changes to the ACF local JSON files with the database. Works automatically behind the scenes upon anyone hitting any admin screen. (Activated with the `admin_init` hook.) 

Can't take the credit here. :-) This was courtesy of the Delicious Brains dev crew and was mentioned in a recent blog post.

- https://deliciousbrains.com/advanced-custom-fields-wordpress/, under the header Using the Local JSON feature.
- https://gist.github.com/polevaultweb/32056461d1e4b85426211d2e5f85a3eb, provided code example from the blog.

Testable using the following procedure.

- Temporarily remove all JSON files from `/acf-json`. 
- Log into the admin screen and trash all entries in `wp-admin/edit.php?post_type=acf-field-group`
- Empty the trash for good measure.
- Paste back the deleted JSON files from the folder.
- Reload wp-admin/edit.php?post_type=acf-field-group.

Boom, magic. :-) 