### PR TITLE
Fix Hero Button Attributes and Add Support for 'target' and 'rel'

### DIFF
--- a/templates-global/hero.php
+++ b/templates-global/hero.php
@@ -213,9 +213,9 @@ if ( ! empty( $hero_asset_data['url'] ) ) :
 				$color = get_sub_field( 'button_color' );
 				$external_link = get_sub_field( 'external_link' );
 
-				if( $external_link ) {
+				if ( $external_link ) {
 					$rel_text = 'rel="noopener noreferrer"';
-				}else{
+				} else {
 					$rel_text = '';
 				}
 				/**
@@ -230,9 +230,9 @@ if ( ! empty( $hero_asset_data['url'] ) ) :
 					$button_target    = $button_link_data['target'];
 
 					// Button target is a checkbox. If it's checked, we want target to be '_blank'.
-					if( $button_target )  {
-						$target_text =  'target="_blank"';
-					}else{
+					if ( $button_target ) {
+						$target_text = 'target="_blank"';
+					} else {
 						$target_text = '';
 					}
 				} else {

--- a/templates-global/hero.php
+++ b/templates-global/hero.php
@@ -108,10 +108,10 @@ if ( ! empty( $hero_asset_data['url'] ) ) :
 
 	<?php if ( 'video' === $media_type ) { ?>
 
-			  <video class="d-none d-sm-block" id="media-video" autoplay loop muted>
+			<video class="d-none d-sm-block" id="media-video" autoplay loop muted>
 				<source src="<?php echo $hero_asset_data['url']; ?>" type="video/mp4">
 				<?php echo $hero_asset_data['alt']; ?>
-			  </video>
+			</video>
 		<?php if ( $hero_image_data ) { ?>
 				<img
 				class="d-block d-sm-none"

--- a/templates-global/hero.php
+++ b/templates-global/hero.php
@@ -211,6 +211,13 @@ if ( ! empty( $hero_asset_data['url'] ) ) :
 				the_row();
 				$size = get_sub_field( 'button_size' );
 				$color = get_sub_field( 'button_color' );
+				$external_link = get_sub_field( 'external_link' );
+
+				if( $external_link ) {
+					$rel_text = 'rel="noopener noreferrer"';
+				}else{
+					$rel_text = '';
+				}
 				/**
 				 * The label, URL and target values are inside an ACF 'Link' field.
 				 * They do not have default values, like the other button fields,
@@ -221,14 +228,22 @@ if ( ! empty( $hero_asset_data['url'] ) ) :
 					$button_label     = sanitize_text_field( $button_link_data['title'] );
 					$button_url       = esc_url( $button_link_data['url'] );
 					$button_target    = $button_link_data['target'];
+
+					// Button target is a checkbox. If it's checked, we want target to be '_blank'.
+					if( $button_target )  {
+						$target_text =  'target="_blank"';
+					}else{
+						$target_text = '';
+					}
 				} else {
+					// The link field was not filled out. Create some defaults.
 					$button_label  = 'Label Missing!';
 					$button_url    = '#';
-					$button_target = '_self';
+					$target_text   = '';
 				}
 
-				$text = '<a class="btn btn-%3$s btn-%4$s mr-2 mb-2" href="%1$s" target="%4%s">%2$s</a>';
-				echo wp_kses( sprintf( $text, $button_url, $button_label, $size, $color, $button_target ), wp_kses_allowed_html( 'post' ) );
+				$text = '<a class="btn btn-%3$s btn-%4$s mr-2 mb-2" href="%1$s" %5$s %6$s >%2$s</a>';
+				echo wp_kses( sprintf( $text, $button_url, $button_label, $size, $color, $target_text, $rel_text ), wp_kses_allowed_html( 'post' ) );
 				endwhile;
 			echo '</div>';
 		} else {


### PR DESCRIPTION
Resolves #200 

A malformed URL `target` attribute is causing all Hero buttons created with our ACF loop field to open in new tabs, regardless of whether or not the user requested it. All buttons have code that looks like `target="%s"` because of an error in my `sprintf()` syntax - I put a `%` where a `$` should have gone.

Recent rounds of QA on our sites also indicated that we were not properly honoring the _open in new tab_ or _external link_ options on these hero buttons. While the user could select those options, we were not properly applying those settings.

Changes proposed are:

- Fix the `sprintf()` bug by replacing the `%` in the `target` placeholder with a `$`, and use the correct variable
- Add code to read our Button component's 'external link' button and apply `rel="noopener noreferrer"` when that box has been checked
- Add code to read the 'open in new tab' button in the WordPress/ACF link chooser and apply `target="_blank"` when that box has been checked