### PR TITLE
Updated WYSIWYG Settings on Card Body

### DIFF
--- a/acf-json/group_602edd7eb0e61.json
+++ b/acf-json/group_602edd7eb0e61.json
@@ -53,7 +53,7 @@
             },
             "default_value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
             "tabs": "all",
-            "toolbar": "basic",
+            "toolbar": "uds_wp_minimal",
             "media_upload": 0,
             "delay": 1
         },
@@ -585,5 +585,5 @@
     "hide_on_screen": "",
     "active": true,
     "description": "Fields for creating static, but customizable, versions of all UDS card types: standard, story, degree, and event.",
-    "modified": 1618008714
+    "modified": 1621986860
 }


### PR DESCRIPTION
Resolves #157

Changes to both fix a potential issue when editing card body (the interface to create links was not working consistently), and to bring the cards in line with the UDS standards. As I understand it from the XD, links should not be embedded in the actual body text of a card; they are limited to the links area of the card, and are considered calls to action (like buttons).

Changes suggested in this request:

* Updated the Card fields to use our 'minimal' toolbar, which does not contain a button for creating links. For most users, then, we are solving both the original issue and keeping them in line with the standards.
* Add the 'text' version of the toolbar, which has more options, for power users who may need more flexibility if non-standard designs are approved.